### PR TITLE
Fixed rotation animation to not animate counter-clockwise

### DIFF
--- a/clock.js
+++ b/clock.js
@@ -1,5 +1,6 @@
 var clock = {
   minute: 0,
+  animLength: 0,
   init: function () {
     this.generateClock();
     this.runClock();
@@ -12,6 +13,10 @@ var clock = {
        '</div>');
     this.$clock.appendTo('body');
     this.addDashes();
+
+    // Initialize the animation
+    this.$clock.children().addClass('normal-anim');
+    this.getAnimLength();
   },
   addDashes: function () {
     var i, dash = $('<div class="dash">');
@@ -20,9 +25,15 @@ var clock = {
         .clone()
         .appendTo(this.$clock)
         .css({
-          'transform': 'rotate('+ (i * 30) +'deg)'
+          'transform': 'rotate(' + (i * 30) + 'deg)'
         });
     }
+  },
+  getAnimLength: function() {
+    // Get the animation length and convert to ms
+    var length = this.$clock.children().css('transition-duration');
+    length = length.replace(/\D+/g, '');
+    this.animLength = length * 1000;
   },
   runClock: function () {
     setInterval(this.setClockFace.bind(this), 1000);
@@ -32,14 +43,48 @@ var clock = {
     this.setMinuteHand();
     this.setHourHand();
   },
+  resetHandToZero: function($hand) {
+    // Switch animation properties
+    this.toggleAnimation($hand);
+    
+    // Invisibly move the hand to 0 degrees
+    this.rotateHand($hand, 0);
+    
+    // Wait for this to render and then
+    // switch the properties back
+    var delay = this.animLength * 0.05;
+    setTimeout(this.toggleAnimation.bind(this), delay, $hand);
+  },
+  toggleAnimation: function($hand) {
+    $hand.toggleClass('normal-anim');
+    $hand.toggleClass('invis-anim');
+  },
+  rotateHand: function($hand, angle) {
+    $hand.css({
+      'transform': 'rotate(' + angle + 'deg)'
+    });
+  },
   setHandAngle: function ($hand, number, max) {
     var rotationAngle = number / max * 360;
     if (max === 12) { // if it is hour
       rotationAngle += this.minute / 60 * 30;
     }
-    $hand.css({
-      'transform': 'rotate('+rotationAngle+'deg)'
-    });
+    
+    // Animate all the way to 360 instead of 0
+    // for smooth appearance
+    if (rotationAngle === 0) {
+      rotationAngle = 360;
+    }
+    
+    this.rotateHand($hand, rotationAngle);
+    
+    // Need to invisibly reset hand to 0 degrees to avoid
+    // counter-clockwise animation
+    if(rotationAngle === 360) {
+      // Wait for previous animation to finish
+      var delay = this.animLength * 0.9;
+      setTimeout(this.resetHandToZero.bind(this), delay, $hand);
+    }
   },
   setHourHand: function () {
     var hour = moment().format('h'),

--- a/clock.less
+++ b/clock.less
@@ -10,6 +10,9 @@
 @minute-size: @clock-size / 2 * .75;
 @second-size: @clock-size / 2 * .85;
 
+/* animations */
+@anim-length: 1s; // In seconds; max 1s
+
 .clock {
   height: @clock-size;
   width: @clock-size;
@@ -64,5 +67,14 @@
 }
 
 .clock, .hour, .minute, .second, .dash {
-    transition: all 1s ease;
+  transition-property: all;
+  transition-timing-function: ease;
+}
+
+.normal-anim {
+  transition-duration: @anim-length;
+}
+
+.invis-anim {
+  transition-duration: 0;
 }


### PR DESCRIPTION
I noticed that the animation between 59 seconds and 0 seconds (or minutes, or 11 hours and 12 hours) caused the clock hands to animate counter-clockwise due to the interpolated CSS animation values between 354 degrees and 0 degrees for each frame of the animation. I added a fix that involves letting the hands animate to 360 degrees and then "invisibly" resetting the hand to 0 degrees without causing an animation. 

I also made the animation length configurable as a LESS variable; the code will read the animation length and use that value to determine the length of its operations around that tricky 0 degree animation.
